### PR TITLE
Add authentication controller and routes for login/logout and user updates

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,6 +10,7 @@ datasource db {
 model User {
   id        Int      @id @default(autoincrement())
   email     String   @unique
+  password  String
   name      String?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,9 +1,12 @@
 import express from 'express';
+import { authRouter } from './routes/auth.routes';
 import { healthRouter } from './routes/health.routes';
 
 export const app = express();
 
 app.use(express.json());
+
+app.use('/auth', authRouter);
 app.use('/health', healthRouter);
 
 app.get('/', (_req, res) => {

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -1,0 +1,75 @@
+import { Request, Response } from 'express';
+import { prisma } from '../config/prisma';
+
+export class AuthController {
+  static async login(req: Request, res: Response): Promise<Response> {
+    const { email, password } = req.body as { email?: string; password?: string };
+
+    if (!email || !password) {
+      return res.status(400).json({ message: 'Email and password are required' });
+    }
+
+    try {
+      const user = await prisma.user.findUnique({ where: { email } });
+
+      if (!user || user.password !== password) {
+        return res.status(401).json({ message: 'Invalid credentials' });
+      }
+
+      const { password: _password, ...safeUser } = user;
+
+      return res.json({ message: 'Login successful', user: safeUser });
+    } catch (error) {
+      console.error('Login error', error);
+      return res.status(500).json({ message: 'Unable to login' });
+    }
+  }
+
+  static async logout(_req: Request, res: Response): Promise<Response> {
+    return res.json({ message: 'Logout successful' });
+  }
+
+  static async updatePassword(req: Request, res: Response): Promise<Response> {
+    const { userId, newPassword } = req.body as { userId?: number; newPassword?: string };
+
+    if (!userId || !newPassword) {
+      return res.status(400).json({ message: 'User ID and new password are required' });
+    }
+
+    try {
+      const user = await prisma.user.update({
+        where: { id: userId },
+        data: { password: newPassword },
+      });
+
+      const { password: _password, ...safeUser } = user;
+
+      return res.json({ message: 'Password updated successfully', user: safeUser });
+    } catch (error) {
+      console.error('Password update error', error);
+      return res.status(500).json({ message: 'Unable to update password' });
+    }
+  }
+
+  static async updateEmail(req: Request, res: Response): Promise<Response> {
+    const { userId, newEmail } = req.body as { userId?: number; newEmail?: string };
+
+    if (!userId || !newEmail) {
+      return res.status(400).json({ message: 'User ID and new email are required' });
+    }
+
+    try {
+      const user = await prisma.user.update({
+        where: { id: userId },
+        data: { email: newEmail },
+      });
+
+      const { password: _password, ...safeUser } = user;
+
+      return res.json({ message: 'Email updated successfully', user: safeUser });
+    } catch (error) {
+      console.error('Email update error', error);
+      return res.status(500).json({ message: 'Unable to update email' });
+    }
+  }
+}

--- a/src/routes/auth.routes.ts
+++ b/src/routes/auth.routes.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { AuthController } from '../controllers/auth.controller';
+
+export const authRouter = Router();
+
+authRouter.post('/login', AuthController.login);
+authRouter.post('/logout', AuthController.logout);
+authRouter.patch('/password', AuthController.updatePassword);
+authRouter.patch('/email', AuthController.updateEmail);


### PR DESCRIPTION
## Summary
- add authentication controller with login, logout, password, and email update handlers
- expose auth routes and register them in the Express application
- extend Prisma user model to include a password field for credential management

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2e5fb5144832189d88260a8da7a22