### PR TITLE
Hash passwords in seeds and add registration flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev"
   },
+  "prisma": {
+    "seed": "ts-node prisma/seed.ts"
+  },
   "dependencies": {
     "@prisma/client": "^5.19.1",
     "dotenv": "^16.4.5",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,11 +7,65 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model User {
-  id        Int      @id @default(autoincrement())
-  email     String   @unique
-  password  String
-  name      String?
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+model Usuario {
+  uuid      BigInt     @id @default(autoincrement())
+  email     String     @unique @db.VarChar(80)
+  password  String     @db.VarChar(80)
+  nombre    String?    @db.VarChar(150)
+  personal  Personal[]
+  createdAt DateTime   @default(now())
+  updatedAt DateTime   @updatedAt
+  deletedAt DateTime?
+}
+
+model Personal {
+  uuid            BigInt             @id @default(autoincrement())
+  nombre          String             @db.VarChar(150)
+  telefono        String?            @db.VarChar(50)
+  fechaNacimiento DateTime?
+  fechaIngreso    DateTime?
+  usuarioId       BigInt?
+  departamentoId  BigInt?
+  usuario         Usuario?           @relation(fields: [usuarioId], references: [uuid])
+  departamento    Departamento?      @relation(fields: [departamentoId], references: [uuid])
+  proyectos       ProyectoPersonal[]
+  createdAt       DateTime           @default(now())
+  updatedAt       DateTime           @updatedAt
+  deletedAt       DateTime?
+}
+
+model Departamento {
+  uuid      BigInt     @id @default(autoincrement())
+  nombre    String     @db.VarChar(150)
+  personal  Personal[]
+  createdAt DateTime   @default(now())
+  updatedAt DateTime   @updatedAt
+  deletedAt DateTime?
+}
+
+model Proyecto {
+  uuid        BigInt             @id @default(autoincrement())
+  nombre      String             @db.VarChar(150)
+  fechaInicio DateTime?
+  fechaFin    DateTime?
+  estatus     String?            @db.VarChar(150)
+  personas    ProyectoPersonal[]
+  createdAt   DateTime           @default(now())
+  updatedAt   DateTime           @updatedAt
+  deletedAt   DateTime?
+}
+
+model ProyectoPersonal {
+  uuid       BigInt    @id @default(autoincrement())
+  avance     Int?
+  estatus    String?   @db.VarChar(150)
+  proyectoId BigInt
+  personalId BigInt
+  proyecto   Proyecto  @relation(fields: [proyectoId], references: [uuid])
+  personal   Personal  @relation(fields: [personalId], references: [uuid])
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @updatedAt
+  deletedAt  DateTime?
+
+  @@unique([proyectoId, personalId])
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,126 @@
+import { PrismaClient } from '@prisma/client';
+import { hashPassword } from '../src/utils/password';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  console.log('Starting seed for usuarios, departamentos y personal...');
+
+  await prisma.proyectoPersonal.deleteMany();
+  await prisma.personal.deleteMany();
+  await prisma.proyecto.deleteMany();
+  await prisma.usuario.deleteMany();
+  await prisma.departamento.deleteMany();
+
+  const departamentos = await Promise.all([
+    prisma.departamento.create({
+      data: {
+        nombre: 'Recursos Humanos',
+      },
+    }),
+    prisma.departamento.create({
+      data: {
+        nombre: 'Tecnología de la Información',
+      },
+    }),
+    prisma.departamento.create({
+      data: {
+        nombre: 'Finanzas',
+      },
+    }),
+  ]);
+
+  const [
+    adminPassword,
+    juanPassword,
+    mariaPassword,
+  ] = await Promise.all([
+    hashPassword('Admin#123'),
+    hashPassword('Usuario#123'),
+    hashPassword('Usuario#123'),
+  ]);
+
+  await Promise.all([
+    prisma.usuario.create({
+      data: {
+        email: 'admin@empresa.com',
+        // Contraseña original: Admin#123 (cifrada con scrypt)
+        password: adminPassword,
+        nombre: 'Administrador General',
+      },
+    }),
+    prisma.usuario.create({
+      data: {
+        email: 'juan.perez@empresa.com',
+        // Contraseña original: Usuario#123 (cifrada con scrypt)
+        password: juanPassword,
+        nombre: 'Juan Pérez',
+      },
+    }),
+    prisma.usuario.create({
+      data: {
+        email: 'maria.garcia@empresa.com',
+        // Contraseña original: Usuario#123 (cifrada con scrypt)
+        password: mariaPassword,
+        nombre: 'María García',
+      },
+    }),
+  ]);
+
+  const departamentoMap = new Map(
+    departamentos.map((departamento) => [departamento.nombre, departamento] as const),
+  );
+
+  await Promise.all([
+    prisma.personal.create({
+      data: {
+        nombre: 'Juan Pérez',
+        telefono: '555-0101',
+        fechaNacimiento: new Date('1985-03-10'),
+        fechaIngreso: new Date('2020-01-15'),
+        usuario: {
+          connect: { email: 'juan.perez@empresa.com' },
+        },
+        departamento: {
+          connect: { uuid: departamentoMap.get('Tecnología de la Información')!.uuid },
+        },
+      },
+    }),
+    prisma.personal.create({
+      data: {
+        nombre: 'María García',
+        telefono: '555-0102',
+        fechaNacimiento: new Date('1990-07-22'),
+        fechaIngreso: new Date('2021-05-01'),
+        usuario: {
+          connect: { email: 'maria.garcia@empresa.com' },
+        },
+        departamento: {
+          connect: { uuid: departamentoMap.get('Finanzas')!.uuid },
+        },
+      },
+    }),
+    prisma.personal.create({
+      data: {
+        nombre: 'Carlos López',
+        telefono: '555-0103',
+        fechaNacimiento: new Date('1988-11-05'),
+        fechaIngreso: new Date('2019-09-10'),
+        departamento: {
+          connect: { uuid: departamentoMap.get('Recursos Humanos')!.uuid },
+        },
+      },
+    }),
+  ]);
+
+  console.log('Seed completado.');
+}
+
+main()
+  .catch((e) => {
+    console.error('Error durante el seed:', e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -1,5 +1,37 @@
 import { Request, Response } from 'express';
 import { prisma } from '../config/prisma';
+import { hashPassword, verifyPassword } from '../utils/password';
+
+function parseUuid(value: unknown): bigint | null {
+  if (typeof value === 'number' && Number.isInteger(value)) {
+    return BigInt(value);
+  }
+
+  if (typeof value === 'string' && value.trim() !== '') {
+    try {
+      return BigInt(value);
+    } catch (error) {
+      console.error('Invalid bigint string received', { value, error });
+      return null;
+    }
+  }
+
+  return null;
+}
+
+function parseDateValue(value?: string): Date | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+
+  return date;
+}
 
 export class AuthController {
   static async login(req: Request, res: Response): Promise<Response> {
@@ -10,9 +42,15 @@ export class AuthController {
     }
 
     try {
-      const user = await prisma.user.findUnique({ where: { email } });
+      const user = await prisma.usuario.findUnique({ where: { email } });
 
-      if (!user || user.password !== password) {
+      if (!user) {
+        return res.status(401).json({ message: 'Invalid credentials' });
+      }
+
+      const isValidPassword = await verifyPassword(password, user.password);
+
+      if (!isValidPassword) {
         return res.status(401).json({ message: 'Invalid credentials' });
       }
 
@@ -30,16 +68,23 @@ export class AuthController {
   }
 
   static async updatePassword(req: Request, res: Response): Promise<Response> {
-    const { userId, newPassword } = req.body as { userId?: number; newPassword?: string };
+    const { userId, newPassword } = req.body as { userId?: number | string; newPassword?: string };
 
     if (!userId || !newPassword) {
       return res.status(400).json({ message: 'User ID and new password are required' });
     }
 
+    const parsedUserId = parseUuid(userId);
+
+    if (parsedUserId === null) {
+      return res.status(400).json({ message: 'Invalid user ID provided' });
+    }
+
     try {
-      const user = await prisma.user.update({
-        where: { id: userId },
-        data: { password: newPassword },
+      const hashedPassword = await hashPassword(newPassword);
+      const user = await prisma.usuario.update({
+        where: { uuid: parsedUserId },
+        data: { password: hashedPassword },
       });
 
       const { password: _password, ...safeUser } = user;
@@ -52,15 +97,21 @@ export class AuthController {
   }
 
   static async updateEmail(req: Request, res: Response): Promise<Response> {
-    const { userId, newEmail } = req.body as { userId?: number; newEmail?: string };
+    const { userId, newEmail } = req.body as { userId?: number | string; newEmail?: string };
 
     if (!userId || !newEmail) {
       return res.status(400).json({ message: 'User ID and new email are required' });
     }
 
+    const parsedUserId = parseUuid(userId);
+
+    if (parsedUserId === null) {
+      return res.status(400).json({ message: 'Invalid user ID provided' });
+    }
+
     try {
-      const user = await prisma.user.update({
-        where: { id: userId },
+      const user = await prisma.usuario.update({
+        where: { uuid: parsedUserId },
         data: { email: newEmail },
       });
 
@@ -70,6 +121,74 @@ export class AuthController {
     } catch (error) {
       console.error('Email update error', error);
       return res.status(500).json({ message: 'Unable to update email' });
+    }
+  }
+
+  static async registerPersonal(req: Request, res: Response): Promise<Response> {
+    const {
+      email,
+      password,
+      usuarioNombre,
+      personalNombre,
+      telefono,
+      fechaNacimiento,
+      fechaIngreso,
+      departamentoId,
+    } = req.body as {
+      email?: string;
+      password?: string;
+      usuarioNombre?: string;
+      personalNombre?: string;
+      telefono?: string;
+      fechaNacimiento?: string;
+      fechaIngreso?: string;
+      departamentoId?: number | string;
+    };
+
+    if (!email || !password) {
+      return res.status(400).json({ message: 'Email and password are required' });
+    }
+
+    try {
+      const hashedPassword = await hashPassword(password);
+      const departamentoUuid = parseUuid(departamentoId ?? null);
+
+      const result = await prisma.$transaction(async (tx) => {
+        const usuario = await tx.usuario.create({
+          data: {
+            email,
+            password: hashedPassword,
+            nombre: usuarioNombre ?? personalNombre ?? null,
+          },
+        });
+
+        const personal = await tx.personal.create({
+          data: {
+            nombre: personalNombre ?? usuarioNombre ?? 'Sin nombre',
+            telefono: telefono ?? null,
+            fechaNacimiento: parseDateValue(fechaNacimiento),
+            fechaIngreso: parseDateValue(fechaIngreso),
+            usuarioId: usuario.uuid,
+            departamentoId: departamentoUuid ?? undefined,
+          },
+          include: {
+            departamento: true,
+          },
+        });
+
+        return { usuario, personal };
+      });
+
+      const { password: _password, ...safeUsuario } = result.usuario;
+
+      return res.status(201).json({
+        message: 'Usuario y personal creados correctamente',
+        usuario: safeUsuario,
+        personal: result.personal,
+      });
+    } catch (error) {
+      console.error('Error al registrar usuario y personal', error);
+      return res.status(500).json({ message: 'Unable to register user and personal' });
     }
   }
 }

--- a/src/routes/auth.routes.ts
+++ b/src/routes/auth.routes.ts
@@ -5,5 +5,6 @@ export const authRouter = Router();
 
 authRouter.post('/login', AuthController.login);
 authRouter.post('/logout', AuthController.logout);
+authRouter.post('/register', AuthController.registerPersonal);
 authRouter.patch('/password', AuthController.updatePassword);
 authRouter.patch('/email', AuthController.updateEmail);

--- a/src/utils/password.ts
+++ b/src/utils/password.ts
@@ -1,0 +1,29 @@
+import { randomBytes, scrypt as scryptCallback, timingSafeEqual } from 'crypto';
+import { promisify } from 'util';
+
+const scrypt = promisify(scryptCallback);
+const KEY_LENGTH = 64;
+
+export async function hashPassword(password: string): Promise<string> {
+  const salt = randomBytes(16);
+  const derivedKey = (await scrypt(password, salt, KEY_LENGTH)) as Buffer;
+  return `${salt.toString('hex')}:${derivedKey.toString('hex')}`;
+}
+
+export async function verifyPassword(password: string, hashedPassword: string): Promise<boolean> {
+  const [saltHex, keyHex] = hashedPassword.split(':');
+
+  if (!saltHex || !keyHex) {
+    return false;
+  }
+
+  const salt = Buffer.from(saltHex, 'hex');
+  const originalKey = Buffer.from(keyHex, 'hex');
+  const derivedKey = (await scrypt(password, salt, KEY_LENGTH)) as Buffer;
+
+  if (originalKey.length !== derivedKey.length) {
+    return false;
+  }
+
+  return timingSafeEqual(originalKey, derivedKey);
+}


### PR DESCRIPTION
## Summary
- hash seeded usuarios with scrypt and document the original credentials
- add shared password utilities and update auth flows to use Prisma's Usuario model with hashed passwords
- expose a registration endpoint that creates usuarios and personal records with encrypted passwords

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2f5d2837083219c45aff764c81c29